### PR TITLE
Remove leading and trailing whitespace in Registrant and Controller input fields

### DIFF
--- a/src/Address.js
+++ b/src/Address.js
@@ -195,7 +195,7 @@ function Address(props) {
           </div>
           <input
             value={inputValue}
-            onChange={(e) => handleInput(e.currentTarget.value)}
+            onChange={(e) => handleInput(e.currentTarget.value.trim())}
             placeholder={props.placeholder}
             spellCheck={false}
             name="ethereum"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
ensdomains/ens-app#1382
<!--- If there is an associated github issues, please specify here -->

## Description

<!--- Describe your changes in detail -->
As mentioned in the issue, upon pasting an address with leading or trailing spaces into the Registrant and Controller fields, it displays a malformed error. This PR trims off any whitespace:
" 0x00..00  " trimmed to "0x00..00"

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- trim functionality on change event

## How Has This Been Tested?
I have appended and prepended whitespace to an ETH address and then pasted it in the Registrant and Controller fields to see if the 'malformed error' showed up. All unit tests pass in ens app manager when both projects are linked with yarn.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.